### PR TITLE
perf: build SVG annotations off-DOM before attaching to document

### DIFF
--- a/libs/core/src/lib/compute/create/CreateAnnotations.ts
+++ b/libs/core/src/lib/compute/create/CreateAnnotations.ts
@@ -205,13 +205,18 @@ export class CreateAnnotationsImpl<
 
     this.mainContainer.setTextElement(this.svgModel.textElement);
 
-    // Create the svg depending on the text element
+    // Create the SVG off-DOM for batch construction
     this.svgModel.createModel();
-    this.mainContainer.setSvg(this.svgModel.node());
 
     const initialDrawTime = Date.now();
-    // Start computations with the known values
+    // Compute and draw annotations while SVG is still off-DOM
     this.draw.compute().initialDraw();
+
+    // Attach the fully-built SVG to the DOM in a single operation
+    this.mainContainer.setSvg(this.svgModel.node());
+
+    // Draw tags after attaching (getBBox requires live DOM)
+    this.draw.drawTags();
     Debugger.time(initialDrawTime, ' \t initialDraw \t');
   }
 

--- a/libs/core/src/lib/compute/draw/Draw.ts
+++ b/libs/core/src/lib/compute/draw/Draw.ts
@@ -30,9 +30,13 @@ export class Draw<
     // https://github.com/GhentCDH/annotated-text/issues/184
     this.text.createTree();
     createNewBlock(this.annotationModule);
-    this.tag.drawAll();
 
     this.annotation.drawAll();
+    return this;
+  }
+
+  drawTags() {
+    this.tag.drawAll();
     return this;
   }
 

--- a/libs/core/src/lib/compute/model/svg.types.ts
+++ b/libs/core/src/lib/compute/model/svg.types.ts
@@ -48,8 +48,8 @@ export class SvgModel {
   createModel() {
     const textElementDimensions = this.getTextElementDimensions();
 
-    this.svg = select('body')
-      .append('svg')
+    const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    this.svg = select(svgEl)
       .attr('class', styles.svg)
       .attr('width', textElementDimensions.original.width)
       .attr('height', textElementDimensions.original.height) as any;


### PR DESCRIPTION
Title: perf: build SVG annotations off-DOM before attaching

Body:

Summary
Create SVG off-DOM: Changed SvgModel.createModel() to use document.createElementNS instead of select('body').append('svg'), so the SVG element is constructed without being attached to the live document.
Batch DOM insertion: Reordered redrawSvg() so that all annotation elements are computed and drawn into the detached SVG first, then the fully-built SVG is attached to the DOM in a single operation.
Separate tag drawing: Extracted drawTags() from initialDraw() since tag rendering requires getBBox() (which needs a live DOM), while annotation rendering does not.
Why this helps Firefox
Previously, every .append() and .attr() call during annotation drawing triggered DOM mutations on a live SVG element. Firefox re-validates/recalculates the SVG render tree much more aggressively than Chromium on each mutation. By building the entire annotation tree off-DOM and inserting it once, Firefox only needs to process the SVG a single time.

Test plan
 All 297 unit tests pass
 Build succeeds
 Visually verify annotations render correctly in both Chromium and Firefox
 Compare rendering performance in Firefox before/after with a large annotation set